### PR TITLE
Update Blih.py

### DIFF
--- a/public/blih.py
+++ b/public/blih.py
@@ -32,6 +32,7 @@ import hmac
 import hashlib
 import urllib.request
 import urllib.parse
+import ssl
 import json
 import getpass
 
@@ -84,6 +85,11 @@ class blih:
         req.add_header('User-Agent', self._useragent)
 
         try:
+            #Ignore SSL certificate errors
+            ssl_context = ssl.create_default_context()
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+            
             f = urllib.request.urlopen(req)
         except urllib.error.HTTPError as e:
             print ('HTTP Error ' + str(e.code))


### PR DESCRIPTION
Epitech ne semble plus maintenir blih et le certificat SSL de l'endpoint est donc expiré. Voici un fix permettant d'ignorer l'erreur et de continuer d'accéder à nos vieux repos.